### PR TITLE
fix issue https://github.com/joommf/help/issues/13

### DIFF
--- a/oommfodt/oommfodt.py
+++ b/oommfodt/oommfodt.py
@@ -111,5 +111,8 @@ def read(filename, replace_columns=True):
             data.append([float(number) for number in line.split()])
 
     df = pd.DataFrame(data, columns=columns)
+    # next line is required to allow adding list-like attribute to pandas DataFrame
+    # see https://github.com/pandas-dev/pandas/blob/2f9d4fbc7f289a48ed8b29f573675cd2e21b2c89/pandas/core/generic.py#L3631
+    df._metadata.append('units')
     df.units = dict(zip(columns, units))
     return df


### PR DESCRIPTION
Pandas (since 0.2.1) raises a Warning if a a list like element is
assigned to a DataFrame as an attribute. Looking at the source [1],
the right way around this seems to be to register the name of the
attribute in DataFrame._metadata .

[1] https://github.com/pandas-dev/pandas/blob/2f9d4fbc7f289a48ed8b29f573675cd2e21b2c89/pandas/core/generic.py#L3631
[2] https://github.com/pandas-dev/pandas/blob/2f9d4fbc7f289a48ed8b29f573675cd2e21b2c89/pandas/core/generic.py#L3618